### PR TITLE
removing ADO references

### DIFF
--- a/docs/certificates/ai_model_monitor_certificate_generation.md
+++ b/docs/certificates/ai_model_monitor_certificate_generation.md
@@ -109,4 +109,3 @@ The remaining steps are shown here for logical completion, but are not implement
 
 An issue with this approach is that Harald requires "Get Secrets" permission on the KeyVault, so is not truly minimally privileged. There is a tension between Requirements 4 & 7. For Harald to have no privileges in KeyVault, some other system component needs to be able to get secrets on his behalf. This could be implemented as an Azure hosted API (WebApp, Container, Function etc) but this contradicts requirement 7 stating there should be no custom software running in Azure.
 
-Thoughts on how to improve this situation can be found in the project [Wiki](https://dev.azure.com/siemens-microsoft-iai/Siemens-Microsoft-IAI/_wiki/wikis/Siemens-Microsoft-IAI.wiki/95/001-KeyVault-Improvements).

--- a/docs/handover/problem_statement.md
+++ b/docs/handover/problem_statement.md
@@ -207,4 +207,3 @@ More detailed documentation on certificate management can be found at:
 
 - [AI Model Monitor Certificate Generation](../certificates/ai_model_monitor_certificate_generation.md)
 - [Readme for the scripts used in the creation of Model Monitor Identity and Model Manager Identity](../../devops/pipeline/az_cli_scripts/README.md)
-- [ADR on Certificate Management process](https://dev.azure.com/siemens-microsoft-iai/Siemens-Microsoft-IAI/_wiki/wikis/Siemens-Microsoft-IAI.wiki/73/001-Certificate-Management-Process)

--- a/docs/waf/well_architected_framwork_alignment.md
+++ b/docs/waf/well_architected_framwork_alignment.md
@@ -39,7 +39,7 @@ The WAF is built upon 5 pillars
 | Monitor system security, plan incident response | Azure Monitor is now used to store/process logs & metrics data. No alerts have been configured. No Incident Response planning has taken place. | <ul><li> Correlate security and audit events to model application health.</li> <li>Correlate security and audit events to identify active threats. </li><li> Establish automated and manual procedures to respond to incidents. </li><li>Use security information and event management (SIEM) tooling for tracking.</li></ul> | |
 | Identify and protect endpoints | All public endpoints removed. Access to vNet resources is by VPN Gateway only. | |
 | Protect against code-level vulnerabilities | Limited action | Introduce CI/CD pipeline checks such as CredScan and package vulnerability scanning. |
-| Model and test against potential threats | [Threat Model complete](https://dev.azure.com/siemens-microsoft-iai/Siemens-Microsoft-IAI/_git/Siemens-Microsoft-IAI-Reference?path=/docs/threat_modeling/README.md&version=GBdevelopment&_a=contents). | Static code analysis, CredScan and penetration testing should be considered. |
+| Model and test against potential threats | [Threat Model complete](../threat_modeling/README.md). | Static code analysis, CredScan and penetration testing should be considered. |
 
 ## Cost Optimisation
 

--- a/infrastructure/pipeline-agent/variables.tf
+++ b/infrastructure/pipeline-agent/variables.tf
@@ -53,7 +53,7 @@ variable "agent_pool" {
 variable "azdo_org_service_url" {
   type        = string
   description = "The url of the organization on Azure DevOps"
-  default     = "https://dev.azure.com/siemens-microsoft-iai"
+  default     = "https://dev.azure.com/<your-project>"  # Replace <your-project> with your Azure DevOps project
 }
 
 variable "number_of_agents" {


### PR DESCRIPTION
The goal is to remove or replace publicly unavailable links and referrers from the documentation.